### PR TITLE
Konami Code entry (based on Abrham's work)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KDIR := /lib/modules/$(KVERSION)/build
 PWD := "$$(pwd)"
 
 ifdef DEBUG
-	CFLAGS_$(obj-m)
+	CFLAGS_$(obj-m) := -DDEBUG
 endif
 
 default:


### PR DESCRIPTION
All debug messages are only enabled if compiled with the debug flag.
To do so, use `make DEBUG=1`.

Closes #5. The code order check is based on @fantaye-1's implementation and is fully functional.